### PR TITLE
Fixed Description Length for Product Listing Cards and align buttons  (#62)

### DIFF
--- a/src/Components/CardCom.js
+++ b/src/Components/CardCom.js
@@ -43,11 +43,23 @@ export default function ProductCard({ title, price, img, describe }) {
               borderTopRightRadius: "15px",
             }}
           />
-          <CardContent>
+          <CardContent sx={{height: "200px"}}>
             <Typography gutterBottom variant="h5" component="div">
               {title}
             </Typography>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{
+                height: "80px",
+                overflow: "hidden",
+                mb: 1, 
+                textOverflow: "ellipsis", 
+                display: "-webkit-box", 
+                WebkitLineClamp: 4, // Limit to 4 lines of text
+                WebkitBoxOrient: "vertical", 
+              }}
+            >
               {describe}
             </Typography>
             <Typography variant="h6" color="success.main">


### PR DESCRIPTION
#62 
Cards  description limited to 4 lines. if it exceeds then shows the ellipsis(...).  

![Screenshot 2024-10-08 190417](https://github.com/user-attachments/assets/e67af918-6dbd-43e9-8bf0-8d59cd2439ff)
